### PR TITLE
Should restore changed options when switch to another filetype.

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -78,7 +78,9 @@ elseif &filetype == 'xhtml'
 	let b:xml_use_xhtml = 1
 en
 
-							 
+let b:undo_ftplugin = "setlocal cms< isk<"
+  \ . "| unlet b:match_ignorecase b:match_words"
+
 
 
 " NewFileXML -> Inserts <?xml?> at top of new file.                  {{{1


### PR DESCRIPTION
When manually `set filetype=not_xml`, options do not get back to their original values.

I've added `b:undo_ftplugin` option to recover `commentstring`, `iskeyword`, `b:match_ignorecase` and `b:match_words`. Not sure all affected options were here.

This also fixed an error with ftplugin/markdown.vim, it does manipulation on `b:undo_ftplugin` while xml.vim didn't set it.
