### PR TITLE
Better handling key mappings

### DIFF
--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -88,7 +88,8 @@ if ! exists("b:xmlPluginMappedKeys")
 endif
 
 let b:undo_ftplugin = "setlocal cms< isk<"
-  \ . "| unlet b:match_ignorecase b:match_words"
+  \ . "| if exists('b:match_ignorecase') | unlet b:match_ignorecase | endif"
+  \ . "| if exists('b:match_words') | unlet b:match_words | endif"
   \ . "| call <SNR>" . s:SID() . "_unmapKeys()"
   \ . "| unlet b:xmlPluginMappedKeys"
 
@@ -1226,7 +1227,7 @@ endfunction
 " unmapKeys()                         {{{1
 function! s:unmapKeys()
   for mapped in b:xmlPluginMappedKeys
-    execute mapped[0] . "unmap <buffer> " . mapped[1]
+    execute "silent! " . mapped[0] . "unmap <buffer> " . mapped[1]
   endfor
   let b:xmlPluginMappedKeys = []
 endfunction


### PR DESCRIPTION
There are too many default mappings overwrite existed ones.

Add a check for each key.
And add `g:xml_warn_on_duplicate_mapping` option to show corresponding warnings.
