### PR TITLE
Don't use symlinks for windows compatability

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -1,0 +1,2 @@
+let s:path = expand('<sfile>:p:h')
+exec 'so ' . s:path . '/xml.vim'


### PR DESCRIPTION
I've removed the symlink (which doesn't work nicely with git on windows) and replaced it with a little vimscript snipped that just sources ftplugin/xml.vim instead. This works on both windows and linux.
